### PR TITLE
wrapped view guest details button in anchor tag with link

### DIFF
--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -26,7 +26,7 @@
 
             <div class="row u-full-width">
                 <div class="twelve columns">
-                    <button a href="/details" class="button-primary u-full-width" id="viewGuests">View guest details</button>
+                    <a href="/details"> <button class="button-primary u-full-width" id="viewGuests">View guest details</button></a>
                 </div>
             </div>
 


### PR DESCRIPTION
Button on dashboard wasn't leading to the details page. Fixed by wrapping the button in an anchor tag with the /details link in it. 